### PR TITLE
Fix a typo in the pod

### DIFF
--- a/lib/Type/Tiny/XS.pm
+++ b/lib/Type/Tiny/XS.pm
@@ -176,7 +176,7 @@ to provide faster, C-based implementations of some type constraints.
 Type::Tiny, so other data validation frameworks might also consider
 using it!)
 
-Only the following two functions should be considered part of the
+Only the following three functions should be considered part of the
 supported API:
 
 =over


### PR DESCRIPTION
Is this a typo in your docs?

Feel free to ignore if I am missing something.