### PR TITLE
fix Int check on large unsigned integers

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -176,14 +176,14 @@ int
 typetiny_tc_Int(pTHX_ SV* const data PERL_UNUSED_DECL, SV* const sv) {
     assert(sv);
     if (SvOK(sv) && !SvROK(sv) && !isGV(sv)) {
-        if(SvPOKp(sv)){
+        if(SvPOK(sv)){
             return S_pv_is_integer(aTHX_ SvPVX(sv));
         }
-        else if(SvNOKp(sv)) {
-            return S_nv_is_integer(aTHX_ SvNVX(sv));
-        }
-        else if(SvIOKp(sv)){
+        else if(SvIOK(sv)){
             return TRUE;
+        }
+        else if(SvNOK(sv)) {
+            return S_nv_is_integer(aTHX_ SvNVX(sv));
         }
     }
     return FALSE;

--- a/t/02int.t
+++ b/t/02int.t
@@ -22,7 +22,7 @@ the same terms as the Perl 5 programming language system itself.
 
 use strict;
 use warnings;
-use Test::More tests => 17;
+use Test::More tests => 19;
 
 use_ok('Type::Tiny::XS');
 
@@ -42,3 +42,7 @@ ok !Type::Tiny::XS::Int("123\n")  => 'no "123\\n"';
 ok !Type::Tiny::XS::Int("\n123")  => 'no "\\n123"';
 ok !Type::Tiny::XS::Int("2.3")    => 'no "2.3"';
 ok !Type::Tiny::XS::Int( 2.3 )    => 'no 2.3';
+my $maxuint = ~0;
+ok Type::Tiny::XS::Int( $maxuint )    => 'yes MAXUINT';
+my $as_string = sprintf '%f', $maxuint;
+ok Type::Tiny::XS::Int( $maxuint )    => 'yes MAXUINT after use as float';


### PR DESCRIPTION
Large unsigned integers can't always be converted to floats without
losing precision.  Checking the NOKp flag and then the NV flag will end
up checking against an inaccurate value and won't register as an
integer.

The `p` flags should not be used for type checking, as they represent
that any value exists in the related slot.  Their value may not be
accurate.

POK is still checked first, as values like '0e0' will set the IOK flag
if used as a number.