### PR TITLE
quoted encoding for Enum[] in Type::Tiny via EnumQ[]

### DIFF
--- a/t/08enum.t
+++ b/t/08enum.t
@@ -21,7 +21,7 @@ the same terms as the Perl 5 programming language system itself.
 
 use strict;
 use warnings;
-use Test::More tests => 12;
+use Test::More tests => 21;
 
 use_ok('Type::Tiny::XS');
 
@@ -38,3 +38,15 @@ ok !$check->({})                            => 'no {}';
 ok !$check->([])                            => 'no []';
 ok !$check->("")                            => 'no ""';
 ok !$check->(undef)                         => 'no undef';
+
+my $quoted_check = Type::Tiny::XS::get_coderef_for('Enum["a b", "c, d", "-\""]');
+
+ok  $quoted_check->("a b")                         => 'yes "a b"';
+ok  $quoted_check->("c, d")                        => 'yes "c, d"';
+ok  $quoted_check->("-\"")                         => 'yes "-\""';
+ok !$quoted_check->("quux")                        => 'no "quux"';
+ok !$quoted_check->("FOO")                         => 'no "FOO"';
+ok !$quoted_check->({})                            => 'no {}';
+ok !$quoted_check->([])                            => 'no []';
+ok !$quoted_check->("")                            => 'no ""';
+ok !$quoted_check->(undef)                         => 'no undef';


### PR DESCRIPTION
This is a better fix for perl rt 129729 (we can actually XS-ify this
sub now) and fixes the bug in perl rt 133141 which is much harder to
work around.  We define a new encoding for "Enum" in the form of EnumQ
which has QUOTELIKE strings as parameters.  This lets us unambiguously
handle any content in strings.

By defining a new encoding we should remain compatible with older versions
of Type::Tiny and newer versions of Type::Tiny will continue to work
with older versions of Type::Tiny::XS (just won't be able to inline).